### PR TITLE
adopt apiregistration.k8s.io/v1 and apiextensions.k8s.io/v1

### DIFF
--- a/charts/k8s-cloudwatch-adapter-crd/templates/crd.yaml
+++ b/charts/k8s-cloudwatch-adapter-crd/templates/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalmetrics.metrics.aws

--- a/charts/k8s-cloudwatch-adapter/templates/apiservice.yaml
+++ b/charts/k8s-cloudwatch-adapter/templates/apiservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.external.metrics.k8s.io

--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -160,7 +160,7 @@ subjects:
   name: horizontal-pod-autoscaler
   namespace: kube-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalmetrics.metrics.aws

--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -107,7 +107,7 @@ spec:
   selector:
     app: k8s-cloudwatch-adapter
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.external.metrics.k8s.io

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalmetrics.metrics.aws


### PR DESCRIPTION
Replaces:
• `apiregistration.k8s.io/v1beta1` with `apiregistration.k8s.io/v1` (available since 1.10.0)
• `apiextensions.k8s.io/v1beta1` with `apiextensions.k8s.io/v1` (available since 1.16.0)
The v1beta1 versions are deprecated in Kubernetes version 1.22.