### PR TITLE
load local region by fallingback to AWS_REGION env

### DIFF
--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -1,8 +1,9 @@
 package aws
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -11,18 +12,19 @@ import (
 	"k8s.io/klog"
 )
 
-// GetLocalRegion gets the region ID from the instance metadata.
+// GetLocalRegion gets the region ID from the instance metadata, falling back to AWS_REGION env.
 func GetLocalRegion() string {
 	resp, err := http.Get("http://169.254.169.254/latest/meta-data/placement/availability-zone/")
 	if err != nil {
 		klog.Errorf("unable to get current region information, %v", err)
-		return ""
+		return os.Getenv("AWS_REGION")
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("cannot read response from instance metadata, %v", err)
+		return os.Getenv("AWS_REGION")
 	}
 
 	// strip the last character from AZ to get region ID


### PR DESCRIPTION
on EKS clusters instance metadata URL is blocked, and therefore the region for the pod can be loaded from AWS_REGION env variable injected by PIW.

we see errors like
```
I0117 16:28:46.718978       7 provider_external.go:18] Received request for namespace: lumosingest-production, metric name: lumosingest-cloudtrailcollect-sqs-queue-length, metric selectors:
I0117 16:28:46.719093       7 client.go:52] using AWS Region:
E0117 16:28:46.719120       7 client.go:79] err: MissingRegion: could not find region configuration
E0117 16:28:46.719125       7 provider_external.go:32] bad request: MissingRegion: could not find region configuration
```
And HPAs see errors like
```
  ScalingActive  False   FailedGetExternalMetric  the HPA was unable to compute the replica count: unable to get external metric ats-production/ats-elasticsearchsync-sqs-queue-length/nil: unable to fetch metrics from external metrics API: MissingRegion: could not find region configuration
```


since some old clusters still allow access to instance metadata, currently added a fallback to env when instance metadata fails.
