### PR TITLE
Removing unused imports from util.go

### DIFF
--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -1,16 +1,11 @@
 package aws
 
 import (
-	"io"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-
-	"k8s.io/klog"
 )
 
 // GetLocalRegion gets the region ID from the instance metadata using IMDSv2, falling back to AWS_REGION env.


### PR DESCRIPTION
Found in https://github.com/lyft/k8s-cloudwatch-adapter-private/pull/306:
 44.53s  16.34 pkg/aws/util.go:4:2: "io" imported and not used
 44.53s  16.34 pkg/aws/util.go:5:2: "net/http" imported and not used
 44.53s  16.34 pkg/aws/util.go:7:2: "time" imported and not used
 44.53s  16.34 pkg/aws/util.go:13:2: "k8s.io/klog" imported and not used

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
